### PR TITLE
ci: change deploy workflows to manual trigger

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -1,10 +1,12 @@
 name: Deploy to Dev
 
 on:
-  pull_request:
-    paths-ignore:
-      - 'terraform/**'
-      - '*.md'
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: 'Branch or tag to deploy'
+        required: true
+        default: 'main'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/prod.yml
+++ b/.github/workflows/prod.yml
@@ -1,8 +1,11 @@
 name: Deploy to Prod
 
 on:
-  release:
-    types: [published]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Release tag to deploy'
+        required: true
 
 concurrency:
   group: production

--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -1,11 +1,12 @@
 name: Deploy to QA
 
 on:
-  push:
-    branches: [main]
-    paths-ignore:
-      - 'terraform/**'
-      - '*.md'
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: 'Branch or tag to deploy'
+        required: true
+        default: 'main'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
  Deploy workflows now require manual trigger via workflow_dispatch.
  This allows infrastructure to be provisioned on-demand while keeping
  the CI/CD pipeline intact.